### PR TITLE
Fix SK Payment QR Code generation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,6 @@
     "require": {
         "haveapi/client": "0.13.*",
         "rikudou/skqrpayment": "^4.2",
-        "endroid/qr-code": "^2.3"
+        "endroid/qr-code": "^4.7"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,7 @@
 {
     "require": {
-        "haveapi/client": "0.13.*"
+        "haveapi/client": "0.13.*",
+        "rikudou/skqrpayment": "^4.2",
+        "endroid/qr-code": "^2.3"
     }
 }

--- a/cs/nastroje/qr.php
+++ b/cs/nastroje/qr.php
@@ -1,6 +1,9 @@
 <?php 
-  
-include 'phpqrcode/qrlib.php'; 
+
+require_once '../../vendor/autoload.php';
+use rikudou\SkQrPayment\QrPayment;
+use Rikudou\Iban\Iban\IBAN;
+
 
 $output_textate = date("Ymd");
 //$iban = $_GET['iban'];
@@ -9,6 +12,7 @@ $vs = $_GET['vs'];
 
 if($_GET['country'] == "cz") 
 {
+	include 'phpqrcode/qrlib.php'; 
 	$text = "SPD*1.0*ACC:CZ0420100000002200041594*AM:".$amount."*CC:CZK*X-VS:".$vs."*MSG:QRPLATBA"; 
 	   
 	$ecc = 'L'; 
@@ -19,87 +23,18 @@ if($_GET['country'] == "cz")
 }
 else if($_GET['country'] == "sk") 
 {
-	
 
-	$outputate = date("Ymd");
 	$iban = 'SK2083300000002601502873';//$_GET['iban'];
-	$amount = $_GET['amount'];
-	$vs = $_GET['vs'];
 
-	$data = implode("\t", array(
-		0 => '',
-		1 => '1',
-		2 => implode("\t", array(
-			true,
-			$amount,						// SUMA
-			'EUR',						// JEDNOTKA
-			$outputate,					// DATUM
-			$vs,					// VARIABILNY SYMBOL
-			'0',						// KONSTANTNY SYMBOL
-			'0',						// SPECIFICKY SYMBOL
-			'',
-			'QR platba SK',					// POZNAMKA
-			'1',
-			$iban,	// IBAN
-			'FIOZSKBA',					// SWIFT
-			'0',
-			'0'
-		))
-	));
+	$payment = new QrPayment(new IBAN($iban));
+	$payment->setAmount(floatval($amount))
+			->setComment('QR platba SK')
+			->setCurrency('EUR')
+			->setVariableSymbol($vs);
 
-	$output = strrev(hash("crc32b", $data, TRUE)) . $data;
-	$x = proc_open("/usr/bin/xz '--format=raw' '--lzma1=lc=3,lp=0,pb=2,dict=128KiB' '-c' '-'", [0 => ["pipe", "r"], 1 => ["pipe", "w"]], $file);
-	fwrite($file[0], $output);
-	fclose($file[0]);
-	$str = stream_get_contents($file[1]);
-	fclose($file[1]);
-	proc_close($x);
-	$output = bin2hex("\x00\x00" . pack("v", strlen($output)) . $str);
-	$text = "";
-	for ($i = 0;$i < strlen($output);$i++) 
-	{
-		$text .= str_pad(base_convert($output[$i], 16, 2), 4, "0", STR_PAD_LEFT);
-	}
-	$len = strlen($text);
-	$r = $len % 5;
-	if ($r > 0) 
-	{
-		$file = 5 - $r;
-		$text .= str_repeat("0", $file);
-		$len += $file;
-	}
-	$len = $len / 5;
-	$output = str_repeat("_", $len);
-	for ($i = 0;$i < $len;$i += 1) 
-	{
-		$output[$i] = "0123456789ABCDEFGHIJKLMNOPQRSTUV"[bindec(substr($text, $i * 5, 5))];
-	}
-	//die($output);
-	$ecc = 'L'; 
-	$fileixel_Size = 4; 
-	$frame_Size = 4; 
-
-	QRcode::png($output, false, $ecc, $fileixel_Size, $frame_size);
-	/*if (!empty($output)) {
-		$u = '/chart?chs=125x124&cht=qr&chld=L|0&choe=UTF-8&chl=' . $output;
-		$s = @fsockopen("chart.googleapis.com", 80, $e, $r, 1);
-		if ($s) {
-			$h = "GET " . $u . " HTTP/1.0\r\n";
-			$h .= "Host: chart.googleapis.com\r\n";
-			$h .= "Connection: close\r\n\r\n";
-			fwrite($s, $h); $e = ''; $c = "";
-			do {
-				$e .= fgets($s, 128);
-			} while (strpos($e, "\r\n\r\n") === false);
-			while (!feof($s)) {
-				$c .= fgets($s, 4096);
-			}
-			fclose($s);
-		}
-		header('Content-Type: image/png');
-		echo $c;
-	        echo $output; 
-	}*/
+	$qrCode = $payment->getQrCode();
+	header('Content-Type: image/png');
+	echo $qrCode->getRawString();
 }
  
 ?> 


### PR DESCRIPTION
This commit fixes SK Payment QR Code generation, by using rikudou/skqrpayment library, and endroid/qr-code as QR code generation library.

I scanned the QR Code with my Tatra Banka app, it works fine, and generally, I have only good experiences with this library, the QR Code always worked.

Note: For proper functionality of this, PHP script calls `where xz` to find Linux/Windows `xz` library to compress the contents of QR code, thus it also uses `exec`, so it needs to be enabled in PHP.

Note: @Kerrycek Videl som tvoj note ktorý si zmazal. :rofl: Díky že si to nevzdal, keďže ja som používal QR kód na platbu vždy (dokým to fungovalo) a bolo to super. Ale tiež, predtým než som našiel skqrpayment knižnicu, išlo ma neskutočne poraziť z toho :joy: 