### PR TITLE
Add recipient bank account name to SK QR code

### DIFF
--- a/cs/nastroje/qr.php
+++ b/cs/nastroje/qr.php
@@ -30,6 +30,7 @@ else if($_GET['country'] == "sk")
                         ->setComment('QR platba SK')
                         ->setCurrency('EUR')
                         ->setVariableSymbol($vs)
+                        ->setPayeeName('vpsFree.cz')
                         ->setXzBinary('/run/current-system/sw/bin/xz');
 
         $qrCode = $payment->getQrCode();


### PR DESCRIPTION
Some time ago, Slovak banks added functionality to verify recipient bank account name, to avoid money being sent to wrong recipient. To avoid unnecessary "are you sure to send the money to the bank account" dialog, this commit adds valid recipient bank account name.

The code was tested and works fully fine without any changes to dependencies versions.